### PR TITLE
Increase IOSIZE in hellworld and warpdrive cases

### DIFF
--- a/darshan/helloworld/helloworld.c
+++ b/darshan/helloworld/helloworld.c
@@ -21,7 +21,7 @@
 #include <getopt.h>
 #include <limits.h>
 
-#define IOSIZE 20000
+#define IOSIZE 200000
 
 static int example1A(const char* dir, int rank, int nprocs);
 

--- a/darshan/helloworld/helloworld.qsub
+++ b/darshan/helloworld/helloworld.qsub
@@ -15,3 +15,6 @@ rm -rf /grand/projects/ATPESC2021/usr/$USER/helloworld
 
 # submit job
 aprun -n 256 -N 64 ./helloworld /grand/projects/ATPESC2021/usr/$USER/
+
+# delete the new file to avoid exhausing the ATPESC quota
+rm -rf /grand/projects/ATPESC2021/usr/$USER/helloworld

--- a/darshan/warpdrive/warpdriveA.c
+++ b/darshan/warpdrive/warpdriveA.c
@@ -21,7 +21,7 @@
 #include <getopt.h>
 #include <limits.h>
 
-#define IOSIZE 20000
+#define IOSIZE 200000
 
 static int example1A(const char* dir, int rank, int nprocs);
 

--- a/darshan/warpdrive/warpdriveA.qsub
+++ b/darshan/warpdrive/warpdriveA.qsub
@@ -15,3 +15,6 @@ rm -rf /grand/projects/ATPESC2021/usr/$USER/warpdriveA
 
 # submit job
 aprun -n 256 -N 64 ./warpdriveA /grand/projects/ATPESC2021/usr/$USER/
+
+# delete new file to avoid exhausting ATPESC quota
+rm -rf /grand/projects/ATPESC2021/usr/$USER/warpdriveA

--- a/darshan/warpdrive/warpdriveB.c
+++ b/darshan/warpdrive/warpdriveB.c
@@ -21,7 +21,7 @@
 #include <getopt.h>
 #include <limits.h>
 
-#define IOSIZE 20000
+#define IOSIZE 200000
 
 static int example1B(const char* dir, int rank, int nprocs);
 

--- a/darshan/warpdrive/warpdriveB.qsub
+++ b/darshan/warpdrive/warpdriveB.qsub
@@ -15,3 +15,6 @@ rm -rf /grand/projects/ATPESC2021/usr/$USER/warpdriveB
 
 # submit job
 aprun -n 256 -N 64 ./warpdriveB /grand/projects/ATPESC2021/usr/$USER/
+
+# delete new file to avoid exhausting ATPESC quota
+rm -rf /grand/projects/ATPESC2021/usr/$USER/warpdriveB


### PR DESCRIPTION
As discussed during ATPESC2021, the existing configuration of the hands-on cases didn't write enough data to show off the parallel IO performance of theta.alcf.anl.gov.  This commit increases the `IOSIZE` parameter in both the `helloworld` and `warpdrive` cases.

The commit message is below.

---

This commit increases the IOSIZE to 200000 (2e5) in the helloworld and warpdive cases in order to show off the true performance of the parallel filesystem and MPI-IO.

The prior value of this parameter was 2e4, but during ATPESC2021 this proved inadequate to demonstrate the intended performance on theta.alcf.anl.gov.  In particular, the warpdrive cases both wrote data at 225-250 MiB/s, with the non-collective warpdriveB the faster of the two.

Increasing IOSIZE increases I/O performance substantially, with warpdriveA writing at 1300MiB/s and warpdriveB writing
at 400MiB/s.  A similar change to the helloworld case also improves its performance to 1300MiB/s.

Because increasing the IOSIZE increases the size of the written file proportionally (to 25GiB), this commit also modifies the respective qsub scripts to delete the files after executing helloworld and the warpdrive cases.  This should minimize the risk of future ATPESC uses accidentally exhausing the collective project quota with scratch files.